### PR TITLE
Fix setup.py: man page full path is now doc/man/man1/torf.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     install_requires   = ['torf>=1.3', 'pyxdg'],
 
     entry_points       = { 'console_scripts': [ 'torf = torfcli:run' ] },
-    data_files         = [('share/man/man1', ['man/man1/torf.1'])],
+    data_files         = [('share/man/man1', ['doc/man/man1/torf.1'])],
 
     classifiers        = [
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Since c05ef98, man page is autogenerated from Markdown source into _doc/man/man1_. `setup.py` is still refering the former path _man/man1/torf.1_.