### PR TITLE
Update AUR link in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,7 +102,7 @@ Installation
 ------------
 
 The latest release is available on `PyPI <https://pypi.org/project/torf-cli>`_
-and on `AUR <https://aur.archlinux.org/packages/python-torf-cli/>`_.
+and on `AUR <https://aur.archlinux.org/packages/torf-cli/>`_.
 
 
 pipx


### PR DESCRIPTION
Update AUR link in readme to reflect package name change from `python-torf-cli` to `torf-cli`.

Looks like the AUR package name has changed, this PR updates it.

This program is sweet, by the way. The output is very pretty, and it's obvious a lot of care and thought has gone into the features.

BTW, is setting `info.entropy` something that that you came up with, or is it an established convention?