### PR TITLE
Don't present lists containing a single file only

### DIFF
--- a/tests/test_verify.py
+++ b/tests/test_verify.py
@@ -243,12 +243,11 @@ def test_multifile_torrent__correct_size_but_corrupt(tmp_path, create_torrent, h
     assert cap.err == f'{_vars.__appname__}: {content_path} does not satisfy {torrent_file}\n'
 
     if hr_enabled:
-        assert clear_ansi(cap.out) == regex(rf'^\s*Error  Corruption in piece 31, at least one of these files is corrupt:$',
+        assert clear_ansi(cap.out) == regex(rf'^\s*Error  Corruption in piece 31 in {file1}$',
                                             flags=re.MULTILINE)
-        assert clear_ansi(cap.out) == regex(rf'^\s*      {file1}$', flags=re.MULTILINE)
     else:
         assert_no_ctrl(cap.out)
-        assert cap.out == regex((rf'^Error\tCorruption in piece 31, at least one of these files is corrupt:\t{file1}$'),
+        assert cap.out == regex((rf'^Error\tCorruption in piece 31 in {file1}$'),
                                 flags=re.MULTILINE)
 
 

--- a/torfcli/_ui.py
+++ b/torfcli/_ui.py
@@ -484,7 +484,7 @@ class _HumanStatusReporter(_StatusReporterBase):
             return line
 
     def _format_error(self, exception, torrent):
-        if isinstance(exception, torf.VerifyContentError) and len(torrent.files) > 1:
+        if isinstance(exception, torf.VerifyContentError) and len(exception.files) > 1:
             lines = [f'Corruption in piece {exception.piece_index+1}, '
                      f'at least one of these files is corrupt:']
             for filepath in exception.files:
@@ -504,7 +504,7 @@ class _MachineStatusReporter(_StatusReporterBase):
                           f'{info.filepath}'))
 
     def _format_error(self, exception, torrent):
-        if isinstance(exception, torf.VerifyContentError) and len(torrent.files) > 1:
+        if isinstance(exception, torf.VerifyContentError) and len(exception.files) > 1:
             lines = [f'Corruption in piece {exception.piece_index+1}, '
                      f'at least one of these files is corrupt:']
             lines.extend(exception.files)


### PR DESCRIPTION
Currently, if a piece in the middle of a file is corrupt, the CLI tool will say "at least one of these files is corrupt:", followed by that single file. This is a bit silly, and the library is already doing the right thing (i.e., the error message plainly states that the file is corrupt). Interestingly, the CLI tool also simply passes on that error message for single-file torrents, so doing the same thing in the case of a single possible corrupt file might have been the intention in the first place.