### PR TITLE
Provide a way to infer a basename for verification

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ that combine commonly used options.
 Documentation is available as a man page, or you can `read it here
 <https://rndusr.github.io/torf-cli/torf.1.html>`_.
 
-The only depdencies are `torf <https://pypi.org/project/torf/>`_ and `pyxdg
+The only dependencies are `torf <https://pypi.org/project/torf/>`_ and `pyxdg
 <https://pypi.org/project/pyxdg/>`_.
 
 

--- a/torfcli/_config.py
+++ b/torfcli/_config.py
@@ -30,11 +30,10 @@ USAGE
     {_vars.__appname__} PATH [OPTIONS] [-o TORRENT]    # Create torrent
     {_vars.__appname__} -i INPUT                       # Display torrent
     {_vars.__appname__} -i INPUT [OPTIONS] -o TORRENT  # Edit torrent
-    {_vars.__appname__} [-b] -i TORRENT PATH           # Verify file content
+    {_vars.__appname__} -i TORRENT PATH                # Verify file content
 
 ARGUMENTS
     PATH                   Path to torrent's content
-    --basename, -b         Use torrent name as basename to find contents at
     --exclude, -e PATTERN  Glob pattern that is used to exclude files
                            (e.g. "*.txt")
     --exclude-regex, -er PATTERN

--- a/torfcli/_config.py
+++ b/torfcli/_config.py
@@ -30,10 +30,11 @@ USAGE
     {_vars.__appname__} PATH [OPTIONS] [-o TORRENT]    # Create torrent
     {_vars.__appname__} -i INPUT                       # Display torrent
     {_vars.__appname__} -i INPUT [OPTIONS] -o TORRENT  # Edit torrent
-    {_vars.__appname__} -i TORRENT PATH                # Verify file content
+    {_vars.__appname__} [-b] -i TORRENT PATH           # Verify file content
 
 ARGUMENTS
     PATH                   Path to torrent's content
+    --basename, -b         Use torrent name as basename to find contents at
     --exclude, -e PATTERN  Glob pattern that is used to exclude files
                            (e.g. "*.txt")
     --exclude-regex, -er PATTERN
@@ -90,6 +91,7 @@ class CLIParser(argparse.ArgumentParser):
 _cliparser = CLIParser(add_help=False)
 
 _cliparser.add_argument('PATH', nargs='?')
+_cliparser.add_argument('--basename', '-b', action='store_true')
 _cliparser.add_argument('--exclude', '-e', default=[], action='append')
 _cliparser.add_argument('--exclude-regex', '-er', default=[], action='append')
 _cliparser.add_argument('--in', '-i', default='')

--- a/torfcli/_main.py
+++ b/torfcli/_main.py
@@ -174,7 +174,7 @@ def _verify_mode(ui, cfg):
         skip_files = cfg['verbose'] > 0
         try:
             path = cfg['PATH']
-            if cfg['basename']:
+            if path[-1] == '/':
                 path = os.path.join(path,
                                     torrent.metainfo['info'].get('name', ''))
             success = torrent.verify(path, callback=sr.verify_callback,

--- a/torfcli/_main.py
+++ b/torfcli/_main.py
@@ -174,7 +174,7 @@ def _verify_mode(ui, cfg):
         skip_files = cfg['verbose'] > 0
         try:
             path = cfg['PATH']
-            if path[-1] == '/':
+            if path[-1] == os.path.sep:
                 path = os.path.join(path,
                                     torrent.metainfo['info'].get('name', ''))
             success = torrent.verify(path, callback=sr.verify_callback,

--- a/torfcli/_main.py
+++ b/torfcli/_main.py
@@ -11,6 +11,7 @@
 
 import sys
 import datetime
+import os.path
 
 import torf
 from . import _vars
@@ -172,8 +173,11 @@ def _verify_mode(ui, cfg):
     with ui.StatusReporter() as sr:
         skip_files = cfg['verbose'] > 0
         try:
-            success = torrent.verify(cfg['PATH'],
-                                     callback=sr.verify_callback,
+            path = cfg['PATH']
+            if cfg['basename']:
+                path = os.path.join(path,
+                                    torrent.metainfo['info'].get('name', ''))
+            success = torrent.verify(path, callback=sr.verify_callback,
                                      interval=PROGRESS_INTERVAL,
                                      skip_on_error=skip_files)
         except torf.TorfError as e:


### PR DESCRIPTION
This probably cannot be merged as-is, but maybe you'd consider implementing something similar to it.

Utilities I've used up to this point for verifying downloads have included the torrent's name string as the last component in the path at which they expect the contents to be. Now I'd have to resort to two steps: first extract the name, then append it to the path for verification. This is especially troublesome if I want to verify many torrents at once. With a flag like this one, I could simply call `torf` in a loop without having to change the path on each iteration.