### PR TITLE
replace tabs with line break

### DIFF
--- a/torfcli/_ui.py
+++ b/torfcli/_ui.py
@@ -265,7 +265,7 @@ class _MachineFormatter(_FormatterBase):
         return int(torrent.piece_size)
 
     def files(self, torrent):
-        return '\t'.join(str(f) for f in torrent.files)
+        return '\n'.join(str(f) for f in torrent.files)
 
     def comment(self, torrent):
         return torrent.comment.splitlines()
@@ -278,8 +278,8 @@ class _MachineFormatter(_FormatterBase):
     def info(self, key, value, newline=None):
         # Join multiple values with a tab character
         if not isinstance(value, str) and isinstance(value, abc.Sequence):
-            value = '\t'.join(str(v) for v in value)
-        sys.stdout.write(f'{key}\t{value}\n')
+            value = '\n'.join(str(v) for v in value)
+        sys.stdout.write(f'\n{key}\n{value}\n')
         _utils.flush(sys.stdout)
 
     def infos(self, pairs):


### PR DESCRIPTION
you obviously don't use vim or normal terminal work. everything revolves
around copying lines or paragraphs

vim has to dictate the output . this is the only sane output I pipe
everything to vim and copy paste my entire work is in vim I read the
internet in vim. V I M

let's say I want to copy the magnet I press G k. takes two seconds . the
only requirement is everything on separate lines. if I want to copy a
paragraph K. one key if the output has a basic understanding of lines
breaks

 # bla blah lectures

it's a reason ls is not tree. inventing a new file format is the last
anyone needs. and formatting is just to be turned off. I don't know
anyone that use glamour formatting in gh for instance since I pipe gh
view to vim to copy lines and vim already color markdown glamour
formatting is completely useless  . just shows that some people don't
have the patience to learn vim no one that used vim would design output
like this

 # change machine formatting name  to default normal vim formatting

this doesn't matter to me but the name makes no sense.  machine readable out put is json not insane patch work of sed commands that is trying to find tabs and new lines

and the default out put is not for a machine it's just a tired old
terminal slave. clearest possible way I can. make this is think about
the commands ls tree jq and how they are used. if you changed ls to tree
every one would panic and change it back . you probably use windows or
something I don't understand how this happened
