### PR TITLE
Fix timezone-dependent expected values in merge option tests

### DIFF
--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -825,7 +825,7 @@ def test_nowebseed_option(capsys, mock_content):
                 ),
             ],
             {
-                'creation_date': datetime(2012, 11, 10, 9, 8, 7),
+                'creation_date': datetime.fromtimestamp(1352534887),
                 'created_by': None,
                 'name': 'New Name',
                 'path_map': {

--- a/tests/test_edit.py
+++ b/tests/test_edit.py
@@ -430,7 +430,7 @@ def test_edit_magnet_uri_and_create_torrent_with_validation_disabled(capsys, tmp
                 '{"created by": null}',
             ],
             {
-                'creation_date': datetime(2012, 11, 10, 9, 8, 7),
+                'creation_date': datetime.fromtimestamp(1352534887),
                 'created_by': None,
                 'private': None,
                 'path_map': {


### PR DESCRIPTION
The tests hardcoded datetime as the expected creation date for Unix timestamp, which is the correct local time only in UTC+1. Tests can be executed in an environment with a different timezone, causing the tests to fail

Replace the hardcoded literals with datetime.fromtimestamp so the expected value is derived from the timestamp at runtime and is correct in any timezone

This bug was discovered while I was packaging torf-cli for Debian